### PR TITLE
Fix 'NameError No resource, method, or local variable named `default'…

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 deb_file = node['icaclient']['deb_file']
-install_deps = default['icaclient']['install_deps'] 
+install_deps = node['icaclient']['install_deps']
 
 execute 'add-architecture' do
   command 'dpkg --add-architecture i386'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,17 @@
+require 'chefspec'
+
+# ChefSpec unit test for icaclient::default recipe
+describe 'icaclient::default' do    
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe)
+  end
+
+  before do
+    stub_command('dpkg -l icaclient').and_return(1)
+  end
+  
+  it 'installs packages' do
+    expect(chef_run).to install_package('libxerces-c3.1')
+    expect(chef_run).to install_package('libwebkitgtk-1.0-0')    
+  end
+end


### PR DESCRIPTION
Hi I get the following error running the Chef cookbook.

> NameError:
>        No resource, method, or local variable named `default' for`Chef::Recipe "default"'

This is due to the line `install_deps = default['icaclient']['install_deps']` in recipes\default.rb.  Updating this to `install_deps = node['icaclient']['install_deps']` seems to fix the issue.

I've added a ChefSpec test, the test fails without the change to the recipes\default.rb file.

This is the first time I've created a Git branch or pull request so I hope I've done this correctly.
Thanks,
Rich.
