### PR TITLE
Add options '--force-yes' to package installation (package installati…

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ end
 
 install_deps.each do |pkg|
   package pkg
+  options '--force-yes'
 end
 
 cookbook_file "/tmp/#{deb_file}" do


### PR DESCRIPTION
Hi, 

I've added `options '--force-yes' to the package installation.  Without this the package installation fails for me when testing on a Ubuntu 14.04 desktop (using the Vagrant box box-cutter/ubuntu1404-desktop)

```
==> default: [2015-08-18T11:01:15+00:00] ERROR: apt_package[libc6:i386] (icaclient::default line 32) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '100'
==> default: ---- Begin output of apt-get -q -y install libc6:i386=2.19-0ubuntu6.6 ----
==> default: STDOUT: Reading package lists...
==> default: Building dependency tree...
==> default: Reading state information...
==> default: The following extra packages will be installed:
==> default:   gcc-4.9-base:i386 libgcc1:i386
==> default: Suggested packages:
==> default:   glibc-doc:i386 locales:i386
==> default: The following NEW packages will be installed:
==> default:   gcc-4.9-base:i386 libc6:i386 libgcc1:i386
==> default: 0 upgraded, 3 newly installed, 0 to remove and 289 not upgraded.
==> default: Need to get 4057 kB of archives.
==> default: After this operation, 9851 kB of additional disk space will be used.
==> default: Get:1 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main gcc-4.9-base i386 4.9.1-0ubuntu1 [14.9 kB]
==> default: Get:2 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main libc6 i386 2.19-0ubuntu6.6 [3994 kB]
==> default: Get:3 http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main libgcc1 i386 1:4.9.1-0ubuntu1 [47.9 kB]
==> default: Fetched 4057 kB in 3min 17s (20.6 kB/s)
==> default: Selecting previously unselected package libc6:i386.
==> default: (Reading database ... 185013 files and directories currently installed.)
==> default: Preparing to unpack .../libc6_2.19-0ubuntu6.6_i386.deb ...
==> default: Unpacking libc6:i386 (2.19-0ubuntu6.6) ...
==> default: Selecting previously unselected package libgcc1:i386.
==> default: Preparing to unpack .../libgcc1_1%3a4.9.1-0ubuntu1_i386.deb ...
==> default: Unpacking libgcc1:i386 (1:4.9.1-0ubuntu1) ...
==> default: STDERR: E: Could not open file /var/cache/apt/archives/gcc-4.9-base_4.9.1-0ubuntu1_i386.deb - open (2: No such file or directory)
==> default: E: Unable to determine file size for fd -1 - fstat (9: Bad file descriptor)
==> default: E: Read error - read (9: Bad file descriptor)
==> default: E: Internal error, could not locate member control.tar.{gzbz2xzlzma}
==> default: E: Prior errors apply to /var/cache/apt/archives/gcc-4.9-base_4.9.1-0ubuntu1_i386.deb
==> default: E: Prior errors apply to /var/cache/apt/archives/libc6_2.19-0ubuntu6.6_i386.deb
==> default: E: Prior errors apply to /var/cache/apt/archives/libgcc1_1%3a4.9.1-0ubuntu1_i386.deb
==> default: debconf: apt-extracttemplates failed: No such file or directory
==> default: dpkg: error processing archive /var/cache/apt/archives/gcc-4.9-base_4.9.1-0ubuntu1_i386.deb (--unpack):
==> default:  cannot access archive: No such file or directory
==> default: No apport report written because the error message indicates an issue on the local system
==> default: Errors were encountered while processing:
==> default:  /var/cache/apt/archives/gcc-4.9-base_4.9.1-0ubuntu1_i386.deb
==> default: E: Sub-process /usr/bin/dpkg returned an error code (1)
==> default: ---- End output of apt-get -q -y install libc6:i386=2.19-0ubuntu6.6 ----
==> default: Ran apt-get -q -y install libc6:i386=2.19-0ubuntu6.6 returned 100
==> default: [2015-08-18T11:01:15+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

I noticed this option is used in the bash scripts used here to setup the ICA client https://mark911.wordpress.com/2014/06/27/how-to-install-citrix-receiver-icaclient-in-ubuntu-14-04-lts-64-bit-tested-and-working-using-mozilla-firefox/ (whcih is referenced here https://help.ubuntu.com/community/CitrixICAClientHowTo)
