### PR TITLE
Fix selfservice desktop

### DIFF
--- a/files/default/selfservice.desktop
+++ b/files/default/selfservice.desktop
@@ -1,3 +1,4 @@
+[Desktop Entry]
 Encoding=UTF-8
 Version=1.0
 Type=Application

--- a/files/default/selfservice.desktop
+++ b/files/default/selfservice.desktop
@@ -1,0 +1,8 @@
+Encoding=UTF-8
+Version=1.0
+Type=Application
+Name=Citrix Receiver
+Categories=Application;Network;X-Red-Hat-Base;X-SuSE-Core-Internet;
+Icon=/opt/Citrix/ICAClient/icons/manager.png
+TryExec=/opt/Citrix/ICAClient/selfservice
+Exec=/opt/Citrix/ICAClient/selfservice --icaroot /opt/Citrix/ICAClient

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,13 +2,13 @@
 # Recipe:: default
 #
 # Copyright 2015 Tamas Molnar
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -72,4 +72,14 @@ end
 link '/usr/lib/mozilla/plugins/npica.so' do
   to '/opt/Citrix/ICAClient/npica.so'
   link_type :symbolic
+end
+
+# Udpate desktop file for Citrix reciever.  There is a bug in the
+# installed .desktop file preventing the launch working on Unity
+# http://discussions.citrix.com/topic/358076-deb-package-uses-icaroot-instead-of-icaroot-spelling-error/#entry1844542
+cookbook_file "/usr/share/applications/selfservice.desktop" do
+  source 'selfservice.desktop'
+  owner  'root'
+  group  'root'
+  mode   '0644'
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 # ChefSpec unit test for icaclient::default recipe
-describe 'icaclient::default' do    
+describe 'icaclient::default' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe)
   end
@@ -9,9 +9,13 @@ describe 'icaclient::default' do
   before do
     stub_command('dpkg -l icaclient').and_return(1)
   end
-  
+
   it 'installs packages' do
     expect(chef_run).to install_package('libxerces-c3.1')
-    expect(chef_run).to install_package('libwebkitgtk-1.0-0')    
+    expect(chef_run).to install_package('libwebkitgtk-1.0-0')
+  end
+
+  it 'creates selfservice.desktop file' do
+    expect(chef_run).to create_cookbook_file('/usr/share/applications/selfservice.desktop')
   end
 end


### PR DESCRIPTION
Hi, 

I've added a cookbook_file to create the .desktop launcher file.  This is to workaround this issue: http://discussions.citrix.com/topic/358076-deb-package-uses-icaroot-instead-of-icaroot-spelling-error/#entry1844542 (which has a work-around referenced here: https://help.ubuntu.com/community/CitrixICAClientHowTo)
